### PR TITLE
Fix typo // "Cancelable" -> "Cancellable"

### DIFF
--- a/src/main/java/de/craftsblock/craftscore/event/Cancellable.java
+++ b/src/main/java/de/craftsblock/craftscore/event/Cancellable.java
@@ -1,6 +1,6 @@
 package de.craftsblock.craftscore.event;
 
-public interface Cancelable {
+public interface Cancellable {
 
     void setCancelled(boolean cancelled);
 


### PR DESCRIPTION
Nothing but a fixed typo